### PR TITLE
Automating CI/CD workflows for testing and releasing the project

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,40 @@
+name: Pull Request Checks
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'zulu' # Alternative distribution options are available.
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and verify
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn -B verify -Dgpg.skip=true org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+          -Dsonar.projectKey=koosty_gatling-tcp-plugin \
+          -Dsonar.organization=koosty \
+          -Dsonar.qualitygate.wait=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release to Maven Central
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'zulu' # Alternative distribution options are available.
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Prepare Release
+        run: mvn -B release:prepare
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Perform Release
+        run: mvn -B release:perform
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Get Version from Checkout
+        id: version
+        run: |
+          cd target/checkout
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.VERSION }}
+          name: Release v${{ steps.version.outputs.VERSION }}
+          draft: false
+          prerelease: false
+          files: target/checkout/target/*.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.github.koosty</groupId>
@@ -12,6 +10,8 @@
     <url>${project.scm.url}</url>
 
     <properties>
+        <releaseVersion>0.1.0</releaseVersion>
+        <developmentVersion>0.2.0-SNAPSHOT</developmentVersion>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -220,6 +220,7 @@
                 </executions>
                 <configuration>
                     <passphraseServerId>gpg.passphrase</passphraseServerId>
+                    <skip>${gpg.skip}</skip>
                 </configuration>
             </plugin>
             <plugin>
@@ -228,6 +229,7 @@
                 <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
+                    <skipPublishing>${skipPublishing}</skipPublishing>
                     <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
@@ -235,6 +237,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.1.1</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <pushChanges>true</pushChanges>
+                    <localCheckout>true</localCheckout>
+                    <releaseVersion>${releaseVersion}</releaseVersion>
+                    <developmentVersion>${developmentVersion}</developmentVersion>
+                    <goal>deploy</goal>
+                    <preparationProfiles>
+                        no-gpg
+                    </preparationProfiles>
+                    <releaseProfiles>
+                        dryRun
+                    </releaseProfiles>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -260,4 +277,20 @@
         <developerConnection>scm:git:${project.scm.url}.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
+
+    <profiles>
+        <profile>
+            <id>no-gpg</id>
+            <properties>
+                <gpg.skip>true</gpg.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>dryRun</id>
+            <properties>
+                <gpg.skip>true</gpg.skip>
+                <skipPublishing>true</skipPublishing>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This pull request introduces automated CI/CD workflows for testing and releasing the project, and enhances the Maven build configuration to better support release management and artifact publishing. The changes add GitHub Actions workflows for pull request checks and Maven Central releases, and update the `pom.xml` to streamline and automate the release process.

**CI/CD automation:**

* Added `.github/workflows/pr-checks.yml` to automatically run tests, SonarQube analysis, and build verification on pull requests targeting the `main` branch.
* Added `.github/workflows/release.yml` to automate the release process to Maven Central, including preparing and performing a Maven release, tagging, and creating a GitHub release.

**Maven build and release enhancements:**

* Added `releaseVersion` and `developmentVersion` properties to `pom.xml` to manage versioning during releases.
* Updated the `maven-release-plugin` configuration in `pom.xml` to automate tagging, versioning, and pushing changes, and to use custom profiles for GPG and dry-run scenarios.
* Added `no-gpg` and `dryRun` Maven profiles to `pom.xml` for skipping GPG signing and publishing when needed.
* Introduced `skip` and `skipPublishing` parameters in plugin configurations to allow conditional execution of signing and publishing steps.