### PR TITLE
Implement connection reuse to measure throughput

### DIFF
--- a/src/main/java/com/github/koosty/gatling/tcp/javaapi/TcpRequestBuilder.java
+++ b/src/main/java/com/github/koosty/gatling/tcp/javaapi/TcpRequestBuilder.java
@@ -17,6 +17,8 @@ public class TcpRequestBuilder implements ActionBuilder {
     private boolean addLengthHeader = false;
     private LengthHeaderType lengthHeaderType;
     private final List<Function<byte[], Boolean>> validators = new ArrayList<>();
+    private boolean reuseConnection = false;
+    private String connectionKey = "default";
     /**
      * Constructs a TcpRequestBuilder with a specified request name.
      *
@@ -72,6 +74,40 @@ public class TcpRequestBuilder implements ActionBuilder {
     }
 
     /**
+     * Enables connection reuse for this TCP request.
+     * When enabled, the same TCP connection will be reused for multiple requests.
+     *
+     * @return This TcpRequestBuilder instance for method chaining.
+     */
+    public  TcpRequestBuilder withReuseConnection() {
+        this.reuseConnection = true;
+        return this;
+    }
+
+    /**
+     * Sets whether to reuse the TCP connection for this request.
+     *
+     * @param reuseConnection A boolean indicating whether to reuse the connection.
+     * @return This TcpRequestBuilder instance for method chaining.
+     */
+    public  TcpRequestBuilder withReuseConnection(boolean reuseConnection) {
+        this.reuseConnection = reuseConnection;
+        return this;
+    }
+
+    /**
+     * Sets a custom connection key to identify the TCP connection.
+     * This is useful when managing multiple connections in a simulation.
+     *
+     * @param connectionKey A string representing the connection key.
+     * @return This TcpRequestBuilder instance for method chaining.
+     */
+    public TcpRequestBuilder withConnectionKey(String connectionKey) {
+        this.connectionKey = connectionKey;
+        return this;
+    }
+
+    /**
      * Converts this Java-based TCP request builder into a Scala-based action builder.
      *
      * @return A Scala-compatible ActionBuilder instance configured with the current settings.
@@ -83,7 +119,9 @@ public class TcpRequestBuilder implements ActionBuilder {
                 message,
                 addLengthHeader,
                 lengthHeaderType,
-                validators
+                validators,
+                reuseConnection,
+                connectionKey
         );
     }
 

--- a/src/main/scala/com/github/koosty/gatling/tcp/TcpRequestActionBuilder.scala
+++ b/src/main/scala/com/github/koosty/gatling/tcp/TcpRequestActionBuilder.scala
@@ -16,13 +16,17 @@ import scala.jdk.CollectionConverters._
  * @param addLengthHeader Whether to add a length header to the message.
  * @param lengthHeaderType Type of length header to use.
  * @param validators List of Java functions to validate the response.
+ * @param reuseConnection Whether to reuse an existing connection.
+ * @param connectionKey Key to identify the connection in the session.
  */
 class TcpRequestActionBuilder(
                                requestName: String,
                                message: Array[Byte],
                                addLengthHeader: Boolean = false,
                                lengthHeaderType: LengthHeaderType = LengthHeaderType.TWO_BYTE_BIG_ENDIAN,
-                               validators: java.util.List[Function[Array[Byte], java.lang.Boolean]] = new java.util.ArrayList()
+                               validators: java.util.List[Function[Array[Byte], java.lang.Boolean]] = new java.util.ArrayList(),
+                               reuseConnection: Boolean = false,
+                               connectionKey: String = "default",
                              ) extends ActionBuilder {
 
   override def build(ctx: ScenarioContext, next: Action): Action = {
@@ -39,6 +43,8 @@ class TcpRequestActionBuilder(
       addLengthHeader,
       lengthHeaderType,
       scalaValidators,
+      reuseConnection,
+      connectionKey,
       components.protocol,
       ctx.coreComponents.statsEngine,
       ctx.coreComponents.clock,


### PR DESCRIPTION
This pull request adds support for TCP connection reuse in the Gatling TCP plugin, allowing users to reuse the same TCP connection across multiple requests for more realistic load testing scenarios. It introduces new configuration options to control connection reuse and keying, updates the core action logic to manage connection lifecycles, and adds comprehensive tests for this feature.

**Connection Reuse Feature:**

* Added `reuseConnection` and `connectionKey` fields to `TcpRequestBuilder`, along with new builder methods (`withReuseConnection`, `withReuseConnection(boolean)`, and `withConnectionKey`) to configure connection reuse and keying.

**Connection Management Logic:**

* Updated `TcpRequestAction` to check for an existing socket in the session and reuse it if possible, or create and store a new one if not. Handles proper cleanup and removal of connections from the session when no longer needed or on error.

**Testing:**

* Added a test case to `TcpRequestActionSpec` that verifies TCP connection reuse works as expected by sending two requests over the same connection and checking correct session and response handling.

These changes improve the flexibility and realism of TCP load testing by enabling persistent connections and fine-grained connection control.